### PR TITLE
Update Cassandra version & Add configs in nova-compute.conf

### DIFF
--- a/roles/cassandra/tasks/debian.yml
+++ b/roles/cassandra/tasks/debian.yml
@@ -31,9 +31,8 @@
 - name: Remove openjdk 6
   apt: name=openjdk-6-jre-headless state=absent
 
-# Supported Cassandra 2.0.10 only
 - name: Install cassandra
-  apt: name=cassandra=2.0.10 state=present update_cache=yes
+  apt: name=cassandra=2.2.7 state=present update_cache=yes
 
 - name: Force stop cassandra
   service: name=cassandra state=stopped

--- a/roles/cassandra/tasks/redhat.yml
+++ b/roles/cassandra/tasks/redhat.yml
@@ -27,9 +27,10 @@
   when: ansible_distribution_major_version == '6'
 
 - name: Install cassandra
-  yum: name=cassandra20-2.0.10 state=present
-  notify:
-    - Stop cassandra
+  yum: name=cassandra22-2.2.7 state=present
+
+- name: Force systemd daemon reload
+  command: systemctl daemon-reload
 
 - meta: flush_handlers
 

--- a/roles/compute_post/tasks/main.yml
+++ b/roles/compute_post/tasks/main.yml
@@ -96,6 +96,21 @@
   notify:
     - Restart nova compute
 
+- name: Update nova-compute DEFAULT config
+  ini_file: dest=/etc/nova/nova-compute.conf section=DEFAULT option={{ item.option }} value={{ item.value }} backup=yes
+  with_items:
+    - { option: 'compute_driver', value: 'libvirt.LibvirtDriver' }
+    - { option: 'vncserver_listen', value: '{{ vncserver_listen }}' }
+    - { option: 'vncserver_proxyclient_address', value: '{{ vncserver_proxyclient_address }}' }
+    - { option: 'novncproxy_base_url', value: '{{ novncproxy_base_url }}' }
+  notify:
+    - Restart nova compute
+
+- name: Update nova-compute config to use QEMU driver
+  ini_file: dest=/etc/nova/nova-compute.conf section=libvirt option=virt_type value=qemu backup=yes
+  notify:
+    - Restart nova compute
+
 - name: Update nova notification driver
   lineinfile: dest=/etc/nova/nova.conf insertbefore="^notification_driver = $" line={{ item }}
   with_items:

--- a/roles/compute_post/vars/defaults.yml
+++ b/roles/compute_post/vars/defaults.yml
@@ -15,6 +15,13 @@
 #
 ---
 
+my_ip: "{{ mgmt_ip }}"
+
+vncserver_listen: 0.0.0.0
+vncserver_proxyclient_address: "{{ my_ip }}"
+vncserver_proxy_address: "{{ my_ip }}"
+novncproxy_base_url: "http://{{ vncserver_proxy_address }}:6080/vnc_auto.html"
+
 #Mysql
 mysql_admin_username: root
 mysql_hostname: "{{ my_ip }}"


### PR DESCRIPTION
- Updated Cassandra version to 2.2.7
- Added following configs in `nova-compute.conf`

```
[DEFAULT]
compute_driver=libvirt.LibvirtDriver
vncserver_listen = 0.0.0.0
vncserver_proxyclient_address = <local VM IP>
novncproxy_base_url = http://<public VM IP if available, failback to local VM IP>:6080/vnc_auto.html
[libvirt]
virt_type=qemu
```
